### PR TITLE
Add Option to Submit Privately

### DIFF
--- a/src/urlscanio/__main__.py
+++ b/src/urlscanio/__main__.py
@@ -26,7 +26,7 @@ def main():
 async def execute(args, api_key, data_dir, log_level):
     async with urlscan.UrlScan(api_key=api_key, data_dir=data_dir, log_level=log_level) as url_scan:
         if args.investigate:
-            investigation_result = await url_scan.investigate(args.investigate)
+            investigation_result = await url_scan.investigate(args.investigate, args.private)
             print(f"\nScan report URL:\t\t{investigation_result['report']}")
             print(f"Screenshot download location:\t{investigation_result['screenshot']}")
             print(f"DOM download location:\t\t{investigation_result['dom']}\n")
@@ -38,5 +38,5 @@ async def execute(args, api_key, data_dir, log_level):
             print(f"DOM download location:\t\t{retrieve_result['dom']}\n")
 
         elif args.submit:
-            scan_uuid = await url_scan.submit_scan_request(args.submit)
+            scan_uuid = await url_scan.submit_scan_request(args.submit, args.private)
             print(f"\nScan UUID:\t\t{scan_uuid}\n")

--- a/src/urlscanio/urlscan.py
+++ b/src/urlscanio/urlscan.py
@@ -44,10 +44,10 @@ class UrlScan:
         async with aiofiles.open(target_path, "wb") as data:
             await data.write(content)
 
-    async def submit_scan_request(self, url):
+    async def submit_scan_request(self, url, private=False):
         self.logger.info("Requesting scan for %s", url)
         headers = {"Content-Type": "application/json", "API-Key": self.api_key}
-        payload = {"url": url, "public": "on"}
+        payload = {"url": url} if private else {"url": url, "public": "on"} 
         _, response = await self.execute("POST", f"{self.URLSCAN_API_URL}/scan/", headers, payload)
         body = json.loads(response)
         return UUID(body["uuid"])
@@ -79,11 +79,11 @@ class UrlScan:
             await self.save_file(dom_location, response)
             return str(dom_location)
 
-    async def investigate(self, url):
+    async def investigate(self, url, private=False):
         self.logger.info("Starting investigation of %s", url)
         self.logger.debug("Default sleep time between attempts: %d, maximum number of attempts: %d",
                           self.DEFAULT_PAUSE_TIME, self.DEFAULT_MAX_ATTEMPTS)
-        scan_uuid = await self.submit_scan_request(url)
+        scan_uuid = await self.submit_scan_request(url, private)
 
         attempts = 0
         await asyncio.sleep(self.DEFAULT_PAUSE_TIME)

--- a/src/urlscanio/utils.py
+++ b/src/urlscanio/utils.py
@@ -29,6 +29,12 @@ def create_arg_parser():
         type=int
     )
 
+    parser.add_argument(
+        "-p", "--private",
+        help=("Submit the URL in private. Private searches are not shared with other users" ),
+        action="store_true",
+    )
+
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
         "-i", "--investigate",


### PR DESCRIPTION
As a pentester I use urlscan.io for OSINT in the preparation of a job.
Since I don't want to spray paint my clients names all over the net, I needed an option to submit the scan requests passively.

The default is still a public submission, but now you can also call urlscanio with the -p flag to submit privately.